### PR TITLE
Add support for preemptible instances:

### DIFF
--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -215,6 +215,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        instance_name=None,
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
+                       scheduling=None,
                        **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
@@ -230,6 +231,8 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str username: username for the given ssh key, default None
 
         :param str instance_name: name of the instance
+
+        :param str scheduling: scheduling option to use for the instance ("preemptible")
 
         :return: str - instance id of the started instance
         """
@@ -269,6 +272,16 @@ class GoogleCloudProvider(AbstractCloudProvider):
             image_url = '%s%s/global/images/%s' % (
                 GCE_URL, os_cloud, image_id)
 
+        scheduling_option = {}
+        if scheduling:
+          if scheduling == 'preemptible':
+            scheduling_option = {
+              'preemptible': True
+            }
+          else:
+            log.error("Unknown scheduling option: '%s'" % scheduling)
+            raise InstanceError("Unknown scheduling option: '%s'" % scheduling)
+
         # construct the request body
         if instance_name is None:
             instance_name = 'elasticluster-%s' % uuid.uuid4()
@@ -278,6 +291,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
         instance = {
             'name': instance_name,
             'machineType': machine_type_url,
+            'scheduling': scheduling_option,
             'disks': [{
                 'autoDelete': 'true',
                 'boot': 'true',


### PR DESCRIPTION
In the elasticluster config, set:
  scheduling=preemptible

at either the cluster level or node level.
Recommended to be used at the node level for "compute" nodes,
such that the frontend/master is NOT preemptible.
